### PR TITLE
fixed one_edit_insert function and added one more test case

### DIFF
--- a/Chapter 1/4_Palindrome Permutation/PalindromePermutation.py
+++ b/Chapter 1/4_Palindrome Permutation/PalindromePermutation.py
@@ -2,38 +2,33 @@
 import unittest
 
 
-def pal_perm(string):
+def pal_perm(phrase):
     '''function checks if a string is a permutation of a palindrome or not'''
-    array = []
-    for char in string:
-        if char != ' ':
-            array.append(char.lower())
-    # even number of elements
-    if len(array) % 2 == 0:
-        for index in range(len(array)):
-            if char_count(array[index], array) % 2 != 0:
-                return False
-        return True
+    table = [0 for _ in range(ord('z') - ord('a') + 1)]
+    countodd = 0
+    for c in phrase:
+        x = char_number(c)
+        if x != -1:
+            table[x] += 1
+            if table[x] % 2:
+                countodd += 1
+            else:
+                countodd -= 1
 
-    # odd number of elements
-    elif len(array) % 2 != 0:
-        mid_alph_occur_count = 0
-        for index in range(len(array)):
-            if char_count(array[index], array) % 2 != 0:
-                mid_alph_occur_count += 1
-        if mid_alph_occur_count == 1:
-            return True
-        else:
-            return False
+    return countodd <= 1
 
+def char_number(c):
+    a = ord('a')
+    z = ord('z')
+    A = ord('A')
+    Z = ord('Z')
+    val = ord(c)
 
-def char_count(char, array):
-    '''Counts the number of times an alphabet occurs in the string'''
-    count = 0
-    for chars in array:
-        if char == chars:
-            count += 1
-    return count
+    if a <= val <= z:
+        return val - a
+    elif A <= val <= Z:
+        return val - A
+    return -1
 
 
 class Test(unittest.TestCase):
@@ -45,7 +40,8 @@ class Test(unittest.TestCase):
         ('So patient a nurse to nurse a patient so', False),
         ('Random Words', False),
         ('Not a Palindrome', False),
-        ('no x in nixon', True)]
+        ('no x in nixon', True),
+        ('azAZ', True)]
 
     def test_pal_perm(self):
         for [test_string, expected] in self.data:

--- a/Chapter 1/5_One Away/OneAway.py
+++ b/Chapter 1/5_One Away/OneAway.py
@@ -31,7 +31,8 @@ def one_edit_insert(s1, s2):
             if edited:
                 return False
             edited = True
-            i += 1
+            j += 1
+            continue
         i += 1
         j += 1
     return True
@@ -43,6 +44,7 @@ class Test(unittest.TestCase):
         ('pale', 'ple', True),
         ('pales', 'pale', True),
         ('pale', 'bale', True),
+        ('paleabc', 'pleabc', True),
         ('pale', 'ble', False)
     ]
 

--- a/Chapter 1/5_One Away/OneAway.py
+++ b/Chapter 1/5_One Away/OneAway.py
@@ -32,9 +32,9 @@ def one_edit_insert(s1, s2):
                 return False
             edited = True
             j += 1
-            continue
-        i += 1
-        j += 1
+        else:
+            i += 1
+            j += 1
     return True
 
 
@@ -45,7 +45,23 @@ class Test(unittest.TestCase):
         ('pales', 'pale', True),
         ('pale', 'bale', True),
         ('paleabc', 'pleabc', True),
-        ('pale', 'ble', False)
+        ('pale', 'ble', False),
+        ('a', 'b', True),
+        ('', 'd', True),
+        ('d', 'de', True),
+        ('pale', 'pale', True),
+        ('pale', 'ple', True),
+        ('ple', 'pale', True),
+        ('pale', 'bale', True),
+        ('pale', 'bake', False),
+        ('pale', 'pse', False),
+        ('ples', 'pales', True),
+        ('pale', 'pas', False),
+        ('pas', 'pale', False),
+        ('pale', 'pkle', True),
+        ('pkle', 'pable', False),
+        ('pal', 'palks', False),
+        ('palks', 'pal', False)
     ]
 
     def test_one_away(self):


### PR DESCRIPTION
Issue with Chapter1 Q5. OneAway.py

There seems to be a bug in one_edit_insert function.

test case with input ('paleabc', 'pleabc', True) won't pass with current implementation

current implementation

```
def one_edit_insert(s1, s2):
    edited = False
    i, j = 0, 0
    while i < len(s1) and j < len(s2):
        if s1[i] != s2[j]:
            if edited:
                return False
            edited = True
            i += 1
        i += 1
        j += 1
    return True
```

and after the second if statement, after change 'edited' to True,
it should be j += 1, not i and also need to add continue after that.
So it would work with 

```
def one_edit_insert(s1, s2):
    edited = False
    i, j = 0, 0
    while i < len(s1) and j < len(s2):
        if s1[i] != s2[j]:
            if edited:
                return False
            edited = True
            j += 1
            continue
        i += 1
        j += 1
    return True
```

Because j is a pointer index for the longer string among two, it should be j that is updated when there is a first mismatch.
Also once j is updated, we cannot update i and j again yet since we need to check parity at the current position again with only j moved forward by 1
