### PR TITLE
BUG: LinkedList.py: DoubleLinkedList error

### DIFF
--- a/Chapter2/LinkedList.py
+++ b/Chapter2/LinkedList.py
@@ -68,8 +68,8 @@ class DoublyLinkedList(LinkedList):
 
     def add(self, value):
         if self.head is None:
-            self.tail = self.head = LinkedListNode(value, None, self.tail)
+            self.tail = self.head = LinkedListNode(value)
         else:
-            self.tail.next = LinkedListNode(value)
+            self.tail.next = LinkedListNode(value, prevNode=self.tail)
             self.tail = self.tail.next
         return self


### PR DESCRIPTION
DoubleLinkedList didn't set the previous node when adding a new node to the tail.  In a linked list with several nodes, tried ll.tail.prev and it returned None instead of the previous node.