### PR TITLE
Update 42MinimalTree.py

### DIFF
--- a/Chapter4/42MinimalTree.py
+++ b/Chapter4/42MinimalTree.py
@@ -16,7 +16,8 @@ def initiateArrayToBinary(array):
 def arrayToBinary(array, start, end):
     if start > end:
         return ''
-    mid = (start + end) / 2
+    mid = (start + end) // 2 #This must be floor division, otherwise you get a slice error
+    # TypeError: list indices must be integers or slices, not float
     root = Node(array[mid])
     root.left = arrayToBinary(array, start, mid - 1)
     root.right = arrayToBinary(array, mid + 1, end)


### PR DESCRIPTION
Floor division to determine middle. Avoids a TypeError: Indices must be integers, not floats.