### PR TITLE
C01_P06 - Fix IndexError in case of empty string provided

### DIFF
--- a/Chapter1/6_String Compression/StringCompression.py
+++ b/Chapter1/6_String Compression/StringCompression.py
@@ -13,7 +13,8 @@ def string_compression(string):
         counter += 1
 
     # add last repeated character
-    compressed.append(string[-1] + str(counter))
+    if counter:
+        compressed.append(string[-1] + str(counter))
 
     # returns original string if compressed string isn't smaller
     return min(string, ''.join(compressed), key=len)
@@ -23,7 +24,8 @@ class Test(unittest.TestCase):
     '''Test Cases'''
     data = [
         ('aabcccccaaa', 'a2b1c5a3'),
-        ('abcdef', 'abcdef')
+        ('abcdef', 'abcdef'),
+        ('', '')
     ]
 
     def test_string_compression(self):


### PR DESCRIPTION
Most of interviewers can ask about edge cases in provided solutions. 
Main function to calculate compressed string disregarding case when empty
string is provided.
This patch is fixing it. Also relevant test is added.

Alternative: check at the beginning of the function if string is empty

```python
def string_compression(string):
    if not string:
        return string

    compressed = []
    counter = 0

```

```
string_compression("")
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-116-69608d95638d> in <module>
----> 1 string_compression("")

<ipython-input-115-aae8e5095538> in string_compression(string)
     10
     11     # add last repeated character
---> 12     compressed.append(string[-1] + str(counter))
     13
     14     # returns original string if compressed string isn't smaller

IndexError: string index out of range
```