### PR TITLE
C01_P05 solutions are not identical, adding testcase to support this claim

### DIFF
--- a/chapter_01/README.md
+++ b/chapter_01/README.md
@@ -1,0 +1,12 @@
+# Solution in chapter_01/p05_one_away.py are not identical.
+
+The set based solution is incorrect because it passes for permutation of input strings, whereas the are_one_edit_different function correctly declares it as False.
+
+Added following test 
+
+        # permuatation with insert shouldn't match
+        ("ale","elas",False), 
+
+
+def are_one_edit_different_sets(a, b): returns True (which is incorrect)
+def are_one_edit_different(s1, s2): returns False (which is correct)

--- a/chapter_01/p05_one_away.py
+++ b/chapter_01/p05_one_away.py
@@ -98,6 +98,8 @@ class Test(unittest.TestCase):
         ("pkle", "pable", False),
         ("pal", "palks", False),
         ("palks", "pal", False),
+        # permuatation with insert shouldn't match
+        ("ale","elas",False), 
     ]
 
     testable_functions = [are_one_edit_different, are_one_edit_different_sets]


### PR DESCRIPTION
# Solution in chapter_01/p05_one_away.py are not identical.

The set based solution is incorrect because it passes for permutation of input strings, whereas the are_one_edit_different function correctly declares it as False.

Added following test

        # permuatation with insert shouldn't match
        ("ale","elas",False),


def are_one_edit_different_sets(a, b): returns True (which is incorrect)
def are_one_edit_different(s1, s2): returns False (which is correct)