### PR TITLE
added second parameter to newstack initialization

### DIFF
--- a/chapter_03/p01_three_in_one.py
+++ b/chapter_03/p01_three_in_one.py
@@ -117,7 +117,7 @@ def test_stack_does_not_exist():
 
 
 if __name__ == "__main__":
-    newstack = MultiStack(2)
+    newstack = MultiStack(2, 2)
     print(newstack.is_empty(1))
     newstack.push(3, 1)
     print(newstack.peek(1))


### PR DESCRIPTION
Thanks so much for your repo- super helpful! As I was walking through CH 3, in p01_three_in_one.py, line 120, I noticed that the Multistack class has 2 arguments besides self (stack_size, number_of_stacks). When newstack is initialized, there is only one argument given. I just added an additional one with the same value of 2 so it doesn't error. Please let me know what you think. Thanks!