### PR TITLE
docs: fix simple typo, permuatation -> permutation

### DIFF
--- a/chapter_01/p05_one_away.py
+++ b/chapter_01/p05_one_away.py
@@ -66,7 +66,7 @@ class Test(unittest.TestCase):
         ("pkle", "pable", False),
         ("pal", "palks", False),
         ("palks", "pal", False),
-        # permuatation with insert shouldn't match
+        # permutation with insert shouldn't match
         ("ale", "elas", False),
     ]
 


### PR DESCRIPTION
There is a small typo in chapter_01/p05_one_away.py.

Should read `permutation` rather than `permuatation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md