### PR TITLE
update(C04_P09): used deque to avoid slicing

### DIFF
--- a/chapter_04/p09_bst_sequences.py
+++ b/chapter_04/p09_bst_sequences.py
@@ -1,4 +1,5 @@
 from chapter_04.binary_search_tree import BinarySearchTree
+
 from collections import deque
 
 

--- a/chapter_04/p09_bst_sequences.py
+++ b/chapter_04/p09_bst_sequences.py
@@ -1,4 +1,5 @@
 from chapter_04.binary_search_tree import BinarySearchTree
+from collections import deque
 
 
 def find_bst_sequences(bst):
@@ -9,14 +10,14 @@ def find_bst_sequences(bst):
 
 def helper(node):
     if not node:
-        return [[]]
+        return [deque()]
 
     right_sequences = helper(node.right)
     left_sequences = helper(node.left)
     sequences = []
     for right in right_sequences:
         for left in left_sequences:
-            sequences = weave(left, right, [node.key], sequences)
+            sequences = weave(left, right, deque([node.key]), sequences)
     return sequences
 
 
@@ -27,15 +28,16 @@ def weave(first, second, prefix, results):
         result.extend(second)
         results.append(result)
         return results
-
-    head = first[0]
+    head = first.popleft()
     prefix.append(head)
-    results = weave(first[1:], second, prefix, results)
+    results = weave(first, second, prefix, results)
+    first.appendleft(head)
     prefix.pop()
-    head = second[0]
+    head = second.popleft()
     prefix.append(head)
-    results = weave(first, second[1:], prefix, results)
+    results = weave(first, second, prefix, results)
     prefix.pop()
+    second.appendleft(head)
     return results
 
 
@@ -45,8 +47,8 @@ def test_find_bst_sequences():
     bst.insert(1)
     bst.insert(3)
     sequences = find_bst_sequences(bst)
-    assert [2, 1, 3] in sequences
-    assert [2, 3, 1] in sequences
+    assert deque([2, 1, 3]) in sequences
+    assert deque([2, 3, 1]) in sequences
     assert len(sequences) == 2
 
 

--- a/chapter_04/p09_bst_sequences.py
+++ b/chapter_04/p09_bst_sequences.py
@@ -1,6 +1,6 @@
-from chapter_04.binary_search_tree import BinarySearchTree
-
 from collections import deque
+
+from chapter_04.binary_search_tree import BinarySearchTree
 
 
 def find_bst_sequences(bst):


### PR DESCRIPTION
deque gives the ability to remove and add the element at the  beginning of the sequences in constant time since it is implemented using linked list, this also avoids slicing of the sequences on every recursive call. 