### PR TITLE
fix(C01_P04): patching a missed case in the pythonic solution

### DIFF
--- a/chapter_01/p04_palindrome_permutation.py
+++ b/chapter_01/p04_palindrome_permutation.py
@@ -1,10 +1,11 @@
 # O(N)
+import string
 import unittest
 from collections import Counter
 
 
 def clean_phrase(phrase):
-    return phrase.replace(" ", "").lower()
+    return [c for c in phrase.lower() if c in string.ascii_lowercase]
 
 
 def is_palindrome_permutation(phrase):
@@ -64,6 +65,7 @@ class Test(unittest.TestCase):
         ("abba", True),
         ("aabb", True),
         ("a-bba", True),
+        ("a-bba!", True),
         ("Tact Coa", True),
         ("jhsabckuj ahjsbckj", True),
         ("Able was I ere I saw Elba", True),


### PR DESCRIPTION
Added a new test case: where there are multiple, different non-alpha characters in the string. The pythonic solution only accounts for spaces. This PR accounts for any non-alpha characters.

Update chapter_01/p04_palindrome_permutation.py

Feedback: more succinct syntax to only count letters

Co-authored-by: Bryce Drennan

Closes #215 